### PR TITLE
[#4] added conditional intercept option

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ angular.module('app', ['angular-jwt'])
 .config(function Config($httpProvider, jwtInterceptorProvider) {
   jwtInterceptorProvider.tokenGetter = function() {
     return localStorage.getItem('id_token');
-  }
+  };
   $httpProvider.interceptors.push('jwtInterceptor');
 })
 .controller('Controller', function Controller($http) {
@@ -97,6 +97,26 @@ angular.module('app', ['angular-jwt'])
   });
 }
 ````
+
+```js
+angular.module('app', ['angular-jwt'])
+.config(function Config($httpProvider, jwtInterceptorProvider) {
+  jwtInterceptorProvider.tokenGetter = function() {
+    return localStorage.getItem('id_token');
+  };
+  jwtInterceptorProvider.intercept = function(config) {
+    return ! /hola$/.test(config.url);
+  };
+  $httpProvider.interceptors.push('jwtInterceptor');
+})
+.controller('Controller', function Controller($http) {
+  // This request will NOT send the token as the config didn't pass `intercept`
+  $http({
+    url: '/hola',
+    method: 'GET'
+  });
+}
+```
 
 ### Sending different tokens based on URLs
 

--- a/test/unit/angularJwt/services/interceptorSpec.js
+++ b/test/unit/angularJwt/services/interceptorSpec.js
@@ -74,4 +74,65 @@ describe('interceptor', function() {
     });
 
   });
+
+  it('should not intercept if skipAuthorization in request config', function (done) {
+    module( function ($httpProvider, jwtInterceptorProvider) {
+      jwtInterceptorProvider.tokenGetter = function() {
+        return 101;
+      };
+      $httpProvider.interceptors.push('jwtInterceptor');
+    });
+
+    inject(function ($http, $httpBackend) {
+      $http({ skipAuthorization: true, url: '/skip/config'}).success(function (data) {
+        expect(data).to.be.equal('hello');
+        done();
+      });
+
+      $httpBackend.expectGET('/skip/config', function (headers) {
+        return !headers.Authorization;
+      }).respond(200, 'hello');
+      $httpBackend.flush();
+    });
+  });
+
+  it('should not intercept if intercept is defined', function (done) {
+    module( function ($httpProvider, jwtInterceptorProvider) {
+      jwtInterceptorProvider.tokenGetter = function() {
+        return 110;
+      };
+      jwtInterceptorProvider.intercept = function(config) {
+        return /pls-intercept$/.test(config.url);
+      };
+      $httpProvider.interceptors.push('jwtInterceptor');
+    });
+
+    inject(function ($q, $http, $httpBackend) {
+      var deferred = $q.defer();
+
+      $http({ skipAuthorization: true, url: '/skip/pls-intercept'})
+        .error(function (data, status) {
+          expect(status).to.be.equal(401);
+          deferred.resolve();
+        });
+
+      $q.all([
+        deferred.promise,
+        $http({ skipAuthorization: true, url: '/skip/pls-dont-intercept'})
+          .success(function (data) {
+            expect(data).to.be.equal('yaay');
+          })
+      ]).then(function () {
+        done();
+      });
+
+      $httpBackend.expectGET('/skip/pls-intercept', function (headers) {
+        return !headers.Authorization;
+      }).respond(401, '');
+      $httpBackend.expectGET('/skip/pls-dont-intercept', function (headers) {
+        return !headers.Authorization;
+      }).respond(200, 'yaay');
+      $httpBackend.flush();
+    });
+  });
 });


### PR DESCRIPTION
- now you can also define a method `intercept` for `jwtInterceptorProvider` (by default it returns true for all) to skip the interceptor from working for falsy values returned
- added tests for skipping auth
- added example for `intercept` usage
