### PR TITLE
If token is null isTokenExpired should return true

### DIFF
--- a/dist/angular-jwt.js
+++ b/dist/angular-jwt.js
@@ -105,6 +105,10 @@ angular.module('angular-jwt',
     };
 
     this.isTokenExpired = function(token) {
+      
+      if (!token)
+        return true;
+
       var d = this.getTokenExpirationDate(token);
 
       if (!d) {


### PR DESCRIPTION
If my token is null and i try to find if token is expired 
**isTokenExpired()** would throw up error as **"token is null"** 
as it try to getTokenExpirationDate(). 

So i would recommend this patch as it would return token is expired and it can be handled outside as required.

Cheers ! 
