### PR TITLE
Little trick for utf-8 encoding support

### DIFF
--- a/src/angularJwt/services/jwt.js
+++ b/src/angularJwt/services/jwt.js
@@ -11,7 +11,7 @@
           throw 'Illegal base64url string!';
         }
       }
-      return window.atob(output); //polifyll https://github.com/davidchambers/Base64.js
+      return decodeURIComponent(escape(window.atob(output))); //polifyll https://github.com/davidchambers/Base64.js
     }
 
 


### PR DESCRIPTION
Hello !

I had an encoding error with the claims data (I put a name like "Ézéchiel" for example, and the "é" was bad format). This patch fix encoding problem using basic solution from :
http://ecmanaut.blogspot.fr/2006/07/encoding-decoding-utf8-in-javascript.html

Hope this will be helpfull for others.

Regards,

Yannick.