### PR TITLE
Add a parameter `offsetSeconds` to isTokenExpired function

### DIFF
--- a/src/angularJwt/services/jwt.js
+++ b/src/angularJwt/services/jwt.js
@@ -44,14 +44,14 @@
       return d;
     };
 
-    this.isTokenExpired = function(token) {
+    this.isTokenExpired = function(token, offsetSeconds) {
       var d = this.getTokenExpirationDate(token);
-
+      offsetSeconds = offsetSeconds || 0;
       if (!d) {
         return false;
       }
 
       // Token expired?
-      return !(d.valueOf() > new Date().valueOf());
+      return !(d.valueOf() > (new Date().valueOf() + (offsetSeconds * 1000)));
     };
   });


### PR DESCRIPTION
Adds a "fudge-factor" in the computation.
This allows one to refresh their token if the token is about to expire in the next (for example) 60 seconds.  This helps alleviate clock skew and potential races between client and server.