### PR TITLE
Added support for Browserify/Webpack

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+require('./dist/angular-jwt.js');
+module.exports = 'angular-jwt';
+

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "angular-jwt",
   "version": "0.0.7",
   "description": "Library to help you work with JWTs on AngularJS",
-  "main": "dist/angular-jwt.js",
+  "main": "index.js",
   "author": {
     "name": "Martin Gontovnikas",
     "email": "martin@gon.to"


### PR DESCRIPTION
Added `angular-jwt` to module exports so that after installing via npm, the package can be required in the angular module dependency list such as:

angular.module('myApp', [require('angular-jwt')]);

This is helpful for Browserify and Webpack.