### PR TITLE
Force jwtInterceptor to call tokenGetter

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ angular.module('app', ['angular-jwt'])
 ````
 
 ### Force jwtInterceptor to call `tokenGetter` for each request
+
 By default `tokenGetter` won't be called if authorization header has already been set. Sometimes angular caches headers and `tokenGetter` is not called. To force jwtInterceptor call `tokenGetter` for each request set `forceHeadersUpdate` parameter to `true`
 
 ````js
@@ -216,13 +217,11 @@ angular.module('app', ['angular-jwt'])
   
   $httpProvider.interceptors.push('jwtInterceptor');
 }).controller('Controller', function Controller($http) {
-  // If localStorage contains the id_token it will be sent in the request
-  // url will contain access_token=[yourToken]
-  $http({
+   //This header will be replaced by jwtInterceptor's tokenGetter
+   $http({
     url: '/hola',
     method: 'GET',
     headers: {
-    //This header will be replaced by jwtInterceptor's tokenGetter
       Authorization: 'i_will_be_replaced'
     }
   });

--- a/README.md
+++ b/README.md
@@ -201,6 +201,34 @@ angular.module('app', ['angular-jwt'])
 })
 ````
 
+### Force jwtInterceptor to call `tokenGetter` for each request
+By default `tokenGetter` won't be called if authorization header has already been set. Sometimes angular caches headers and `tokenGetter` is not called. To force jwtInterceptor call `tokenGetter` for each request set `forceHeadersUpdate` parameter to `true`
+
+````js
+angular.module('app', ['angular-jwt'])
+.config(function Config($httpProvider, jwtInterceptorProvider) {
+  // Please note we're annotating the function so that the $injector works when the file is minified
+  jwtInterceptorProvider.tokenGetter = ['myService', function(myService) {
+    myService.doSomething();
+    return localStorage.getItem('id_token');
+  }];
+  jwtInterceptorProvider.forceHeadersUpdate = true;
+  
+  $httpProvider.interceptors.push('jwtInterceptor');
+}).controller('Controller', function Controller($http) {
+  // If localStorage contains the id_token it will be sent in the request
+  // url will contain access_token=[yourToken]
+  $http({
+    url: '/hola',
+    method: 'GET',
+    headers: {
+    //This header will be replaced by jwtInterceptor's tokenGetter
+      Authorization: 'i_will_be_replaced'
+    }
+  });
+});
+````
+
 ### Sending the token as a URL Param
 
 ````js

--- a/src/angularJwt/services/interceptor.js
+++ b/src/angularJwt/services/interceptor.js
@@ -1,12 +1,13 @@
- angular.module('angular-jwt.interceptor', [])
+angular.module('angular-jwt.interceptor', [])
   .provider('jwtInterceptor', function() {
 
     this.urlParam = null;
     this.authHeader = 'Authorization';
     this.authPrefix = 'Bearer ';
+    this.forceHeadersUpdate = false;
     this.tokenGetter = function() {
       return null;
-    }
+    };
 
     var config = this;
 
@@ -26,7 +27,7 @@
           } else {
             request.headers = request.headers || {};
             // Already has an Authorization header
-            if (request.headers[config.authHeader]) {
+            if (!config.forceHeadersUpdate && request.headers[config.authHeader]) {
               return request;
             }
           }

--- a/test/unit/angularJwt/services/interceptorSpec.js
+++ b/test/unit/angularJwt/services/interceptorSpec.js
@@ -21,15 +21,15 @@ describe('interceptor', function() {
     });
 
     inject(function ($http, $httpBackend) {
-        $http({url: '/hello'}).success(function (data) {
-          expect(data).to.be.equal('hello');
-          done();
-        });
+      $http({url: '/hello'}).success(function (data) {
+        expect(data).to.be.equal('hello');
+        done();
+      });
 
-        $httpBackend.expectGET('/hello', function (headers) {
-          return headers.Authorization === 'Bearer 123';
-        }).respond(200, 'hello');
-        $httpBackend.flush();
+      $httpBackend.expectGET('/hello', function (headers) {
+        return headers.Authorization === 'Bearer 123';
+      }).respond(200, 'hello');
+      $httpBackend.flush();
     });
 
   });
@@ -43,15 +43,15 @@ describe('interceptor', function() {
     });
 
     inject(function ($http, $httpBackend) {
-        $http({url: '/hello'}).success(function (data) {
-          expect(data).to.be.equal('hello');
-          done();
-        });
+      $http({url: '/hello'}).success(function (data) {
+        expect(data).to.be.equal('hello');
+        done();
+      });
 
-        $httpBackend.expectGET('/hello', function (headers) {
-          return headers.Authorization === 'Bearer 345';
-        }).respond(200, 'hello');
-        $httpBackend.flush();
+      $httpBackend.expectGET('/hello', function (headers) {
+        return headers.Authorization === 'Bearer 345';
+      }).respond(200, 'hello');
+      $httpBackend.flush();
     });
 
   });
@@ -62,15 +62,15 @@ describe('interceptor', function() {
     });
 
     inject(function ($http, $httpBackend) {
-        $http({url: '/hello'}).success(function (data) {
-          expect(data).to.be.equal('hello');
-          done();
-        });
+      $http({url: '/hello'}).success(function (data) {
+        expect(data).to.be.equal('hello');
+        done();
+      });
 
-        $httpBackend.expectGET('/hello', function (headers) {
-          return !headers.Authorization;
-        }).respond(200, 'hello');
-        $httpBackend.flush();
+      $httpBackend.expectGET('/hello', function (headers) {
+        return !headers.Authorization;
+      }).respond(200, 'hello');
+      $httpBackend.flush();
     });
 
   });
@@ -85,16 +85,61 @@ describe('interceptor', function() {
     });
 
     inject(function ($http, $httpBackend) {
-        $http({url: '/hello'}).success(function (data) {
-          expect(data).to.be.equal('hello');
-          done();
-        });
+      $http({url: '/hello'}).success(function (data) {
+        expect(data).to.be.equal('hello');
+        done();
+      });
 
-        $httpBackend.expectGET('/hello?access_token=123', function (headers) {
-          return headers.Authorization === undefined;
-        }).respond(200, 'hello');
-        $httpBackend.flush();
+      $httpBackend.expectGET('/hello?access_token=123', function (headers) {
+        return headers.Authorization === undefined;
+      }).respond(200, 'hello');
+      $httpBackend.flush();
     });
 
   });
+
+  it('should populate authorization header with tokenGetter when the configuration forceHeadersUpdate option is set to true', function(done){
+    module( function ($httpProvider, jwtInterceptorProvider) {
+      jwtInterceptorProvider.forceHeadersUpdate = true;
+      jwtInterceptorProvider.tokenGetter = function() {
+        return 123;
+      };
+      $httpProvider.interceptors.push('jwtInterceptor');
+    });
+
+    inject(function ($http, $httpBackend) {
+      $http({url: '/hello', headers:{'Authorization': '456'}}).success(function (data) {
+        expect(data).to.be.equal('hello');
+        done();
+      });
+
+      $httpBackend.expectGET('/hello', function (headers) {
+        return headers.Authorization === 'Bearer 123';
+      }).respond(200, 'hello');
+      $httpBackend.flush();
+    });
+  });
+
+  it('should not populate authorization header with tokenGetter when authorization header already exists', function(done){
+    module( function ($httpProvider, jwtInterceptorProvider) {
+      jwtInterceptorProvider.tokenGetter = function() {
+        return 123;
+      };
+      $httpProvider.interceptors.push('jwtInterceptor');
+    });
+
+    inject(function ($http, $httpBackend) {
+      $http({url: '/hello', headers:{'Authorization': '456'}}).success(function (data) {
+        expect(data).to.be.equal('hello');
+        done();
+      });
+
+      $httpBackend.expectGET('/hello', function (headers) {
+        return headers.Authorization === '456';
+      }).respond(200, 'hello');
+      $httpBackend.flush();
+    });
+  });
+
+
 });


### PR DESCRIPTION
By default `tokenGetter` won't be called if authorization header has already been set. Sometimes angular caches headers and `tokenGetter` is not called. To force jwtInterceptor call `tokenGetter` for each request set `forceHeadersUpdate` parameter to `true`.
Pull request for [issue](https://github.com/auth0/angular-jwt/issues/60)
