### PR TITLE
Added support for Angular Strict DI mode

### DIFF
--- a/src/angularJwt/services/interceptor.js
+++ b/src/angularJwt/services/interceptor.js
@@ -10,7 +10,7 @@
 
     var config = this;
 
-    this.$get = function ($q, $injector, $rootScope) {
+    this.$get = ['$q', '$injector', '$rootScope', function ($q, $injector, $rootScope) {
       return {
         request: function (request) {
           if (request.skipAuthorization) {
@@ -54,5 +54,6 @@
           return $q.reject(response);
         }
       };
-    };
+    }];
+
   });

--- a/src/angularJwt/services/jwt.js
+++ b/src/angularJwt/services/jwt.js
@@ -1,5 +1,5 @@
  angular.module('angular-jwt.jwt', [])
-  .service('jwtHelper', function($window) {
+  .service('jwtHelper', ['$window', function($window) {
 
     this.urlBase64Decode = function(str) {
       var output = str.replace(/-/g, '+').replace(/_/g, '/');
@@ -53,4 +53,4 @@
       // Token expired?
       return !(d.valueOf() > (new Date().valueOf() + (offsetSeconds * 1000)));
     };
-  });
+  }]);


### PR DESCRIPTION
We want to use `strict mode` for our angular app to avoid production error. 

According to `angular doc`.
"strict-di" mode. This means that the application will fail to invoke functions which do not use explicit function annotation (and are thus unsuitable for minification), as described in the Dependency Injection guide, and useful debugging info will assist in tracking down the root of these bugs.

Our project relays on `angular-jwt`. Thanks for the module. But this module was breaking our code in 
`strict mode`.
Try to merge it fast, we heavily rely on `angular-jwt`.



