### PR TITLE
Potential for inadvertent JWT disclosure

### DIFF
--- a/src/angularJwt/services/interceptor.js
+++ b/src/angularJwt/services/interceptor.js
@@ -4,16 +4,35 @@
     this.urlParam = null;
     this.authHeader = 'Authorization';
     this.authPrefix = 'Bearer ';
+    this.whiteListedDomains = [];
     this.tokenGetter = function() {
       return null;
-    }
+    };
 
     var config = this;
 
-    this.$get = function ($q, $injector, $rootScope) {
+
+    this.$get = function ($q, $injector, $rootScope, urlUtils) {
+
+      function isSafe (url) {
+        var hostname = urlUtils.urlResolve(url).hostname.toLowerCase();
+        for (var i = 0; i < config.whiteListedDomains.length; i++) {
+          var domain = config.whiteListedDomains[i].toLowerCase();
+          if (domain === hostname) {
+            return true;
+          }
+        }
+
+        if (urlUtils.isSameOrigin(url)) {
+          return true;
+        }
+
+        return false;
+      }
+
       return {
         request: function (request) {
-          if (request.skipAuthorization) {
+          if (request.skipAuthorization || !isSafe(request.url)) {
             return request;
           }
 

--- a/src/angularJwt/services/urlUtils.js
+++ b/src/angularJwt/services/urlUtils.js
@@ -1,0 +1,110 @@
+ /**
+  * The content from this file was directly lifted from Angular. It is
+  * unfortunately not a public API, so the best we can do is copy it.
+  *
+  * Angular References:
+  *   https://github.com/angular/angular.js/issues/3299
+  *   https://github.com/angular/angular.js/blob/d077966ff1ac18262f4615ff1a533db24d4432a7/src/ng/urlUtils.js
+  */
+
+ angular.module('angular-jwt.interceptor')
+  .service('urlUtils', function () {
+
+    // NOTE:  The usage of window and document instead of $window and $document here is
+    // deliberate.  This service depends on the specific behavior of anchor nodes created by the
+    // browser (resolving and parsing URLs) that is unlikely to be provided by mock objects and
+    // cause us to break tests.  In addition, when the browser resolves a URL for XHR, it
+    // doesn't know about mocked locations and resolves URLs to the real document - which is
+    // exactly the behavior needed here.  There is little value is mocking these out for this
+    // service.
+    var urlParsingNode = document.createElement("a");
+    var originUrl = urlResolve(window.location.href);
+
+    /**
+     *
+     * Implementation Notes for non-IE browsers
+     * ----------------------------------------
+     * Assigning a URL to the href property of an anchor DOM node, even one attached to the DOM,
+     * results both in the normalizing and parsing of the URL.  Normalizing means that a relative
+     * URL will be resolved into an absolute URL in the context of the application document.
+     * Parsing means that the anchor node's host, hostname, protocol, port, pathname and related
+     * properties are all populated to reflect the normalized URL.  This approach has wide
+     * compatibility - Safari 1+, Mozilla 1+, Opera 7+,e etc.  See
+     * http://www.aptana.com/reference/html/api/HTMLAnchorElement.html
+     *
+     * Implementation Notes for IE
+     * ---------------------------
+     * IE <= 10 normalizes the URL when assigned to the anchor node similar to the other
+     * browsers.  However, the parsed components will not be set if the URL assigned did not specify
+     * them.  (e.g. if you assign a.href = "foo", then a.protocol, a.host, etc. will be empty.)  We
+     * work around that by performing the parsing in a 2nd step by taking a previously normalized
+     * URL (e.g. by assigning to a.href) and assigning it a.href again.  This correctly populates the
+     * properties such as protocol, hostname, port, etc.
+     *
+     * References:
+     *   http://developer.mozilla.org/en-US/docs/Web/API/HTMLAnchorElement
+     *   http://www.aptana.com/reference/html/api/HTMLAnchorElement.html
+     *   http://url.spec.whatwg.org/#urlutils
+     *   https://github.com/angular/angular.js/pull/2902
+     *   http://james.padolsey.com/javascript/parsing-urls-with-the-dom/
+     *
+     * @kind function
+     * @param {string} url The URL to be parsed.
+     * @description Normalizes and parses a URL.
+     * @returns {object} Returns the normalized URL as a dictionary.
+     *
+     *   | member name   | Description    |
+     *   |---------------|----------------|
+     *   | href          | A normalized version of the provided URL if it was not an absolute URL |
+     *   | protocol      | The protocol including the trailing colon                              |
+     *   | host          | The host and port (if the port is non-default) of the normalizedUrl    |
+     *   | search        | The search params, minus the question mark                             |
+     *   | hash          | The hash string, minus the hash symbol
+     *   | hostname      | The hostname
+     *   | port          | The port, without ":"
+     *   | pathname      | The pathname, beginning with "/"
+     *
+     */
+    function urlResolve(url) {
+      var href = url;
+
+      // Normalize before parse.  Refer Implementation Notes on why this is
+      // done in two steps on IE.
+      urlParsingNode.setAttribute("href", href);
+      href = urlParsingNode.href;
+      urlParsingNode.setAttribute('href', href);
+
+      // urlParsingNode provides the UrlUtils interface - http://url.spec.whatwg.org/#urlutils
+      return {
+        href: urlParsingNode.href,
+        protocol: urlParsingNode.protocol ? urlParsingNode.protocol.replace(/:$/, '') : '',
+        host: urlParsingNode.host,
+        search: urlParsingNode.search ? urlParsingNode.search.replace(/^\?/, '') : '',
+        hash: urlParsingNode.hash ? urlParsingNode.hash.replace(/^#/, '') : '',
+        hostname: urlParsingNode.hostname,
+        port: urlParsingNode.port,
+        pathname: (urlParsingNode.pathname.charAt(0) === '/')
+          ? urlParsingNode.pathname
+          : '/' + urlParsingNode.pathname
+      };
+    }
+
+    /**
+     * Parse a request URL and determine whether this is a same-origin request as the application document.
+     *
+     * @param {string|object} requestUrl The url of the request as a string that will be resolved
+     * or a parsed URL object.
+     * @returns {boolean} Whether the request is for the same origin as the application document.
+     */
+    function urlIsSameOrigin(requestUrl) {
+      var parsed = (angular.isString(requestUrl)) ? urlResolve(requestUrl) : requestUrl;
+      return (parsed.protocol === originUrl.protocol &&
+              parsed.host === originUrl.host);
+    }
+
+    return {
+      urlResolve: urlResolve,
+      isSameOrigin: urlIsSameOrigin
+    };
+
+  })

--- a/test/unit/angularJwt/services/interceptorSpec.js
+++ b/test/unit/angularJwt/services/interceptorSpec.js
@@ -34,6 +34,38 @@ describe('interceptor', function() {
 
   });
 
+  it('should not add Authr headers to Cross Origin requests unless whitelisted', function (done) {
+    module( function ($httpProvider, jwtInterceptorProvider) {
+      jwtInterceptorProvider.whiteListedDomains = ['whitelisted.Example.com']
+      jwtInterceptorProvider.tokenGetter = function() {
+        return 123;
+      }
+      $httpProvider.interceptors.push('jwtInterceptor');
+    });
+
+    inject(function ($http, $httpBackend, $q) {
+      $q.all([
+        $http({url: 'http://Example.com/hello' }),
+        $http({url: 'http://www.example.com/hello' }),
+        $http({url: 'http://whitelisted.example.com/hello' })
+      ]).then(function () {
+        done();
+      })
+
+      $httpBackend.expectGET('http://Example.com/hello', function (headers) {
+        return headers.Authorization === undefined;
+      }).respond(200);
+      $httpBackend.expectGET('http://www.example.com/hello', function (headers) {
+        return headers.Authorization === undefined;
+      }).respond(200);
+      $httpBackend.expectGET('http://whitelisted.example.com/hello', function (headers) {
+        return headers.Authorization === 'Bearer 123';
+      }).respond(200);
+
+      $httpBackend.flush();
+    });
+  })
+
   it('should work with promises', function (done) {
     module( function ($httpProvider, jwtInterceptorProvider) {
       jwtInterceptorProvider.tokenGetter = function($q) {


### PR DESCRIPTION
The authorization header should only be added to same-origin requests, not all requests (particularly with bearer tokens).  Otherwise, end-users risk sending their JWTs to non-trusted sites disclosing potentially sensitive information (the payload), and authorization credentials (the JWT itself).  Additionally, while the site implementing this library should always be using TLS, any XHR requests to non-TLS sites would then also reveal this token to a MITM.

This is likely non-obvious to many developers who may inadvertently expose their users simply by making a CORS request, so it should be disabled by default.

This PR changes the logic to only include the `Authorization` header on same-origin requests, but includes the ability to explicitly whitelist domains they need it to be included on.  For example, serving the app from `www.example.com`, but making CORS requests to `api.example.com`.

Thanks!