### PR TITLE
Update README.md clarifying null request options #92

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,19 @@ angular
   });
 ```
 
+**Note: If your `tokenGetter` relies on request `options`.** Be mindful that `checkAuthOnRefresh()` will pass `null` as `options` since the call happens in the run phase of the angular lifecycle and no requests are fired through the angular app. So you need to check if `options` isn't null in your `tokenGetter`:
+
+```js
+...
+tokenGetter: ['options', function (options) {
+  if (options && options.url.substr(options.url.length - 5) == '.html') {
+    return null;
+  }
+  return localStorage.getItem('id_token');
+}],
+...
+```
+
 ### Redirecting the User On Unauthorized Requests
 
 When the user's JWT expires and they attempt a call to a secured endpoint, a 401 - Unauthorized response will be returned. In these cases you will likely want to redirect the user back to the page/state used for authentication so they can log in again. This can be done with the `redirectWhenUnauthenticated` method in the application's `run` block.


### PR DESCRIPTION
Clarifies `authManager.checkAuthOnRefresh()` passing `null` as request `options` for `tokenGetter`.

Introduced in #96