### PR TITLE
interceptor.js not sending the token

### DIFF
--- a/src/angularJwt/services/interceptor.js
+++ b/src/angularJwt/services/interceptor.js
@@ -35,7 +35,7 @@ angular.module('angular-jwt.interceptor', [])
 
       return {
         request: function (request) {
-          if (request.skipAuthorization || !isSafe(request.url)) {
+          if (request.skipAuthorization || isSafe(request.url)) {
             return request;
           }
 


### PR DESCRIPTION
My config is as follows
```
        jwtOptionsProvider.config({
            tokenGetter: ['$cookies', function($cookies) {
                return $cookies.get('token');
            }],
            whiteListedDomains: ["angular.docker"],
            loginPath: '/login',
            unauthenticatedRedirectPath: '/login'
        });

        $httpProvider.interceptors.push('jwtInterceptor');
```

But when trying `$http.get` to my backend, it is not sending token so I get 401 errors.
```
        $http({
            url: 'http://backend/search/basic',
            method: 'GET'
        }).then(
            function (response) {
            },
            function (error) {
            }
        );
```

I've found that the problem is inside `interceptor.js` in this line
`if (request.skipAuthorization || !isSafe(request.url))`

When my backend url `backend` is being called, `isSafe` returns false, because it isn't whitelisted, but as it is being negated inside above condition, it won't send the Token.

If I remove the negation, everything works as supossed... Maybe I am wrong about this, if so please give me some advice about how to get this working.